### PR TITLE
Do not add empty values from CSV

### DIFF
--- a/source_csv.go
+++ b/source_csv.go
@@ -87,7 +87,7 @@ func (csv *CSVSource) NextEntry() (*SourceEntry, error) {
 			// Ignore
 		default:
 			fieldType, ok := csv.types[fieldName]
-			if ok && fieldType != "" && fieldType != "-" {
+			if ok && fieldType != "" && fieldType != "-" && row[i] != "" {
 				se.Values[fieldName] = SourceValue{
 					Type:  csv.types[fieldName],
 					Value: row[i],


### PR DESCRIPTION
This will make the databases more similar to MaxMind databases. It also will prevent decoding errors for missing integers, booleans, etc.

I am open to doing this in another way, if preferred. It could be made configurable, although I don't know what that configuration would look like, possibly a list of keys where empty values would be skipped.
